### PR TITLE
Bump avhengigheter (Kotlin 2 og Ktor 3)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,14 +12,12 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
-          cache: gradle
 
-      - name: Verify Gradle wrapper checksum
-        uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/actions/setup-gradle@v4
 
       - name: Build with Gradle and Publish artifact
         run: ./gradlew build publish

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -14,17 +14,12 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
-          cache: gradle
 
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-
-      - name: Ensure Gradle Wrapper is Downloaded
-        run: ./gradlew --version
+      - uses: gradle/actions/setup-gradle@v4
 
       - name: Get Version
         run:  echo "CURRENT_VERSION=$(./gradlew :printVersion --quiet)" >> $GITHUB_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,34 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
-          cache: gradle
 
-      - name: Cache Gradle wrapper
-        uses: actions/cache@v3
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-wrapper-
-
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-cache-${{ hashFiles('build.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-cache-
-
-      - name: Build
-        run: ./gradlew build --info
-        env:
-          ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
+      - uses: gradle/actions/setup-gradle@v4
 
       - name: Test
-        run: ./gradlew test --console=plain
+        run: ./gradlew build --info
         env:
           ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 group = "no.nav.helsearbeidsgiver"
 version = "0.6.2"
@@ -10,10 +10,13 @@ plugins {
     id("maven-publish")
 }
 
-tasks {
-    withType<KotlinCompile> {
-        kotlinOptions.jvmTarget = "17"
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_21
     }
+}
+
+tasks {
     test {
         useJUnitPlatform()
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,12 @@
 kotlin.code.style=official
 
 # Plugin versions
-kotlinVersion=1.9.10
+kotlinVersion=2.0.21
 kotlinterVersion=3.16.0
 
 # Dependency versions
-kotestVersion=5.7.2
-kotlinxSerializationVersion=1.6.0
-ktorVersion=2.3.4
-mockkVersion=1.13.8
-utilsVersion=0.7.0
+kotestVersion=5.9.1
+kotlinxSerializationVersion=1.8.1
+ktorVersion=3.1.2
+mockkVersion=1.14.0
+utilsVersion=0.9.0


### PR DESCRIPTION
Går også over til Java 21. Dette, og bump til Kotlin 2 og Ktor 3, er de mest substansielle endringene.