### PR TITLE
Legg til enkel caching

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ kotestVersion=5.9.1
 kotlinxSerializationVersion=1.8.1
 ktorVersion=3.1.2
 mockkVersion=1.14.0
-utilsVersion=0.9.0
+utilsVersion=0.10.1

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/pdl/MockUtils.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/pdl/MockUtils.kt
@@ -11,8 +11,10 @@ import io.mockk.every
 import no.nav.helsearbeidsgiver.pdl.domene.PdlError
 import no.nav.helsearbeidsgiver.pdl.domene.PdlErrorExtension
 import no.nav.helsearbeidsgiver.pdl.domene.PdlErrorLocation
+import no.nav.helsearbeidsgiver.utils.cache.LocalCache
 import no.nav.helsearbeidsgiver.utils.test.mock.mockStatic
 import no.nav.helsearbeidsgiver.utils.test.resource.readResource
+import kotlin.time.Duration
 
 const val MOCK_FNR = "test-ident"
 
@@ -37,7 +39,11 @@ fun mockPdlClient(content: String, status: HttpStatusCode): PdlClient {
 
     return mockStatic(::createHttpClient) {
         every { createHttpClient() } returns mockHttpClient
-        PdlClient("url", Behandlingsgrunnlag.INNTEKTSMELDING) { "fake token" }
+        PdlClient(
+            "url",
+            Behandlingsgrunnlag.INNTEKTSMELDING,
+            LocalCache.Config(entryDuration = Duration.ZERO, maxEntries = 1),
+        ) { "fake token" }
     }
 }
 


### PR DESCRIPTION
Legger i første omgang til en enkel caching på tvers av PDL-kall. I fremtiden kan vi gi hvert kall en egen cache dersom vi synes det er verdt ytelsesfordelen.