### PR TITLE
Legg til retry og timeout

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,7 @@ publishing {
 
 dependencies {
     val kotestVersion: String by project
+    val kotlinxCoroutinesVersion: String by project
     val kotlinxSerializationVersion: String by project
     val ktorVersion: String by project
     val mockkVersion: String by project
@@ -62,6 +63,7 @@ dependencies {
     testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
     testImplementation("io.ktor:ktor-client-mock:$ktorVersion")
     testImplementation("io.mockk:mockk:$mockkVersion")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:${kotlinxCoroutinesVersion}")
 }
 
 fun RepositoryHandler.mavenNav(repo: String): MavenArtifactRepository {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@ kotlinterVersion=3.16.0
 
 # Dependency versions
 kotestVersion=5.9.1
+kotlinxCoroutinesVersion=1.10.2
 kotlinxSerializationVersion=1.8.1
 ktorVersion=3.1.2
 mockkVersion=1.14.0

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/pdl/Gradering.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/pdl/Gradering.kt
@@ -1,0 +1,13 @@
+package no.nav.helsearbeidsgiver.pdl
+
+internal object Gradering {
+    val FORTROLIG = "FORTROLIG"
+    val STRENGT_FORTROLIG = "STRENGT_FORTROLIG"
+}
+
+internal fun String.tilKodeverkDiskresjonskode(): String? =
+    when (this) {
+        Gradering.STRENGT_FORTROLIG -> "SPSF"
+        Gradering.FORTROLIG -> "SPFO"
+        else -> null
+    }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/pdl/HttpUtils.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/pdl/HttpUtils.kt
@@ -3,6 +3,8 @@ package no.nav.helsearbeidsgiver.pdl
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.apache5.Apache5
+import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import no.nav.helsearbeidsgiver.utils.json.jsonConfig
@@ -16,9 +18,21 @@ internal fun HttpClientConfig<*>.configure() {
     install(ContentNegotiation) {
         json(jsonConfig)
     }
-}
 
-object GRADERING {
-    val FORTROLIG = "FORTROLIG"
-    val STRENGT_FORTROLIG = "STRENGT_FORTROLIG"
+    install(HttpRequestRetry) {
+        retryOnException(
+            maxRetries = 5,
+            retryOnTimeout = true,
+        )
+        constantDelay(
+            millis = 500,
+            randomizationMs = 500,
+        )
+    }
+
+    install(HttpTimeout) {
+        connectTimeoutMillis = 500
+        requestTimeoutMillis = 500
+        socketTimeoutMillis = 500
+    }
 }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/pdl/GraderingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/pdl/GraderingTest.kt
@@ -1,0 +1,18 @@
+package no.nav.helsearbeidsgiver.pdl
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class GraderingTest : FunSpec({
+    context("Oversett diskresjonskode fra kodeverk") {
+        test("Håndterer gyldige verdier") {
+            Gradering.STRENGT_FORTROLIG.tilKodeverkDiskresjonskode() shouldBe "SPSF"
+            Gradering.FORTROLIG.tilKodeverkDiskresjonskode() shouldBe "SPFO"
+        }
+
+        test("Håndterer ugyldige verdier") {
+            "".tilKodeverkDiskresjonskode() shouldBe null
+            "Whatever".tilKodeverkDiskresjonskode() shouldBe null
+        }
+    }
+})


### PR DESCRIPTION
Siden denne klienten bruker GraphQL-queries så vil ikke det vanlige oppsettet for retries plukke opp alt av feil, men jeg tenker likevel at det er en god start. Det viktigste er uansett retry ved timeout.